### PR TITLE
Set no_proxy environment variable for localhost

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -1,5 +1,5 @@
 import os
-
+os.environ["no_proxy"] = "localhost,127.0.0.1,::1"
 if __name__ == "__main__":
     # 从文件workdir 中读取启动器工作目录
     try:


### PR DESCRIPTION
添加禁止本地回环代理
以解决此报错ValueError: When localhost is not accessible, a shareable link must be created. Please set share=True or check your proxy settings to allow access to localhost.
使用户可以正常启动